### PR TITLE
Output UniProt IDs as primary identifiers in IBA GAF

### DIFF
--- a/scripts/createGAF.pl
+++ b/scripts/createGAF.pl
@@ -211,9 +211,7 @@ foreach my $file (@files){
             $proteinId=~s/\=/\:/g;
             
             my $shortId;   # the gene or protein ID used for GO.
-            if ($goa_mode) {
-                $shortId=$proteinId;
-            }elsif (defined $gpi_uniprot_id_mappings{$proteinId}){
+            if (defined $gpi_uniprot_id_mappings{$proteinId}){
                 $shortId=$gpi_uniprot_id_mappings{$proteinId};
             }elsif ($geneId=~/^Gene|Ensembl/){
                 $shortId=$proteinId;
@@ -658,6 +656,12 @@ foreach my $annotation_id (keys %annotation){
             if (defined $blacklisted_genes{$uniprot_id}){
                 print STDERR "Skipping - obsolete ID missing from latest uniprot_protein.gpi\ttaxon\:$gene_taxon\t$uniprot\n";
                 next;
+            }
+
+            # If GOA mode, primary ID will always be UniProt
+            if ($goa_mode) {
+                $db=$prefix;  # should always be 'UniProtKB'
+                $shortId=$uniprot_id;
             }
             
             my $leaf_ptn;

--- a/scripts/createGAF.pl
+++ b/scripts/createGAF.pl
@@ -23,7 +23,7 @@ use POSIX qw(strftime);
 
 # get command-line arguments
 use Getopt::Std;
-getopts('o:i:a:q:g:n:N:G:b:C:r:t:u:p:c:T:e:s:vVh') || &usage();
+getopts('o:i:a:q:g:n:N:G:b:C:r:t:u:p:c:T:e:s:UvVh') || &usage();
 &usage() if ($opt_h);         # -h for help
 $outDir = $opt_o if ($opt_o);     # -o for (o)utput directory
 $inFile = $opt_i if ($opt_i);     # -i for (i)Input profile file
@@ -43,6 +43,7 @@ $gene_blacklist = $opt_b if ($opt_b);   # -b for the obsoleted UniProt ID blackl
 $complex_termlist = $opt_C if ($opt_C);   # -C for the protein-containing complex descendants file
 $goparentchild = $opt_r if ($opt_r);   # -r for the GO term parent-child relationship file
 $gaf_version = $opt_s if ($opt_s); # -s for output GAF specification version 2.1 (default) or 2.2
+$goa_mode = 1 if ($opt_U); # -g for GOA mode (All gene IDs output as UniProt)
 $errFile = $opt_e if ($opt_e);    # -e for (e)rror file (redirect STDERR)
 $verbose = 1 if ($opt_v);         # -v for (v)erbose (debug info to STDERR)
 $verbose = 2 if ($opt_V);         # -V for (V)ery verbose (debug info STDERR)
@@ -210,7 +211,9 @@ foreach my $file (@files){
             $proteinId=~s/\=/\:/g;
             
             my $shortId;   # the gene or protein ID used for GO.
-            if (defined $gpi_uniprot_id_mappings{$proteinId}){
+            if ($goa_mode) {
+                $shortId=$proteinId;
+            }elsif (defined $gpi_uniprot_id_mappings{$proteinId}){
                 $shortId=$gpi_uniprot_id_mappings{$proteinId};
             }elsif ($geneId=~/^Gene|Ensembl/){
                 $shortId=$proteinId;

--- a/scripts/createGAF.pl
+++ b/scripts/createGAF.pl
@@ -661,7 +661,7 @@ foreach my $annotation_id (keys %annotation){
             # If GOA mode, primary ID will always be UniProt
             if ($goa_mode) {
                 $db=$prefix;  # should always be 'UniProtKB'
-                $shortId=$uniprot_id;
+                $short_id=$uniprot_id;
             }
             
             my $leaf_ptn;


### PR DESCRIPTION
For #65.

This change adds a `-U` option to the `createGAF.pl` script so it shouldn't hurt to merge now.